### PR TITLE
Reactivation resets user

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,9 @@ user accounts.
 The setting `LOGIN_FAILURE_LIMIT` allows to enable a number of allowed login attempts.
 If the settings is not set or set to 0, the feature is disabled.
 
-The backend has a hook that allows to set up notification on exceeded number of allowed
-attempts and locked out account. This can be done by extending the
-`useraudit.backend.AuthFailedLoggerBackend` and overriding `notification` function:
-
-```
-    ...
-    def notification(self):
-        # Custom notification
-        return
-    ...
-```
+When the login failure limit is reached the user account will be deactivated.
+The `useraudit.signals.login_failure_limit_reached` signal is sent when this happens to allow
+for custom notification.
 
 ## Requirements
 

--- a/useraudit/backend.py
+++ b/useraudit/backend.py
@@ -3,6 +3,8 @@ import abc
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.dispatch import receiver
+from django.db.models.signals import pre_save
 from .models import LoginLogger, LoginAttempt
 from .models import LoginAttemptLogger
 from .middleware import get_request
@@ -10,13 +12,25 @@ from .middleware import get_request
 logger = logging.getLogger("django.security")
 
 
-class AuthFailedLoggerBackend(object):
+@receiver(pre_save, sender=settings.AUTH_USER_MODEL)
+def user_pre_save(sender, instance=None, raw=False, **kwargs):
+    user = instance
+    is_new_user = user.pk is None
+    if is_new_user or raw:
+        return
 
-    supports_inactive_user = False
+    # User has been re-activated. Ensure the failed login counter is set to 0 so
+    # that the user isn't inactivated on next login by the AuthFailedLoggerBackend
+    current_user = sender.objects.get(pk=user.pk)
+    if not current_user.is_active and user.is_active:
+        LoginAttemptLogger().reset(user.username)
+
+
+class AuthFailedLoggerBackend(object):
 
     def __init__(self):
         self.login_logger = LoginLogger()
-        self.login_limit = getattr(settings, 'LOGIN_FAILURE_LIMIT', None)
+        self.login_failure_limit = getattr(settings, 'LOGIN_FAILURE_LIMIT', None) or 0
         self.login_attempt_logger = LoginAttemptLogger()
 
     def authenticate(self, **credentials):
@@ -24,32 +38,33 @@ class AuthFailedLoggerBackend(object):
         self.username = credentials.get(get_user_model().USERNAME_FIELD)
         self.login_logger.log_failed_login(self.username, get_request())
         self.login_attempt_logger.increment(self.username)
-        self.attemps_status()
+        self.block_user_if_needed()
 
         return None
 
-    def attemps_status(self):
-        if self.is_login_limit():
-            logger.info("Login failure limit is enabled")
-            if self.is_attempts_exceeded() and self._deactivate_user():
-                self.notification()
-                raise PermissionDenied("Username '%s' has been blocked" % self.username)
+    def block_user_if_needed(self):
+        if not self.is_login_failure_limit_enabled():
+            return
+        logger.debug("Login failure limit is enabled")
+        if self.is_attempts_exceeded():
+            self._deactivate_user()
+            self.notification()
+            logger.info("Login Prevented for user '%s'! Maximum failed logins %d reached!",
+                    self.username, self.login_failure_limit)
+            raise PermissionDenied("Username '%s' has been blocked" % self.username)
 
+    def is_login_failure_limit_enabled(self):
+        return self.login_failure_limit > 0
 
-    def is_login_limit(self):
-        if self.login_limit and self.login_limit > 0:
-            return True
-        return False
-    
     def is_attempts_exceeded(self,):
         count = self._get_count()
-        if count and count >= self.login_limit:
+        if count and count >= self.login_failure_limit:
             return True
         return False
-    
+
     def _get_count(self):
         try:
-            obj = LoginAttempt.objects.get(username = self.username)
+            obj = LoginAttempt.objects.get(username=self.username)
             return obj.count
         except LoginAttempt.DoesNotExist:
             return None
@@ -70,7 +85,7 @@ class AuthFailedLoggerBackend(object):
             logger.warning("Username '%s' has been blocked" % self.username)
             return True
         return False
-  
+
     @abc.abstractmethod
     def notification(self):
         """Place for notification to user that the account has been blocked (Email, SMS etc.)"""

--- a/useraudit/backend.py
+++ b/useraudit/backend.py
@@ -1,16 +1,15 @@
 import logging
-import abc
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.dispatch import receiver
+from django.dispatch import receiver, Signal
 from django.db.models.signals import pre_save
+from .signals import login_failure_limit_reached
 from .models import LoginLogger, LoginAttempt
 from .models import LoginAttemptLogger
 from .middleware import get_request
 
 logger = logging.getLogger("django.security")
-
 
 @receiver(pre_save, sender=settings.AUTH_USER_MODEL)
 def user_pre_save(sender, instance=None, raw=False, **kwargs):
@@ -48,7 +47,8 @@ class AuthFailedLoggerBackend(object):
         logger.debug("Login failure limit is enabled")
         if self.is_attempts_exceeded():
             self._deactivate_user()
-            self.notification()
+            user = self._get_user()
+            login_failure_limit_reached.send(sender=user.__class__, user=user)
             logger.info("Login Prevented for user '%s'! Maximum failed logins %d reached!",
                     self.username, self.login_failure_limit)
             raise PermissionDenied("Username '%s' has been blocked" % self.username)
@@ -85,8 +85,3 @@ class AuthFailedLoggerBackend(object):
             logger.warning("Username '%s' has been blocked" % self.username)
             return True
         return False
-
-    @abc.abstractmethod
-    def notification(self):
-        """Place for notification to user that the account has been blocked (Email, SMS etc.)"""
-        return

--- a/useraudit/password_expiry.py
+++ b/useraudit/password_expiry.py
@@ -102,15 +102,11 @@ from django.dispatch import receiver, Signal
 from django.utils import timezone
 import logging
 from .backend import AuthFailedLoggerBackend
+from .signals import password_has_expired, account_has_expired
 
 logger = logging.getLogger("django.security")
 
-__all__ = ["AccountExpiryBackend",
-           "password_has_expired", "account_has_expired"]
-
-password_has_expired = Signal(providing_args=["user"])
-account_has_expired = Signal(providing_args=["user"])
-
+__all__ = ["AccountExpiryBackend"]
 
 @receiver(pre_save, sender=settings.AUTH_USER_MODEL)
 def user_pre_save(sender, instance=None, raw=False, **kwargs):

--- a/useraudit/signals.py
+++ b/useraudit/signals.py
@@ -1,0 +1,5 @@
+from django.dispatch import Signal
+
+password_has_expired = Signal(providing_args=["user"])
+account_has_expired = Signal(providing_args=["user"])
+login_failure_limit_reached = Signal(providing_args=["user"])


### PR DESCRIPTION
Solves the problems described in issue:

https://github.com/muccg/django-useraudit/issues/4

Solution is to reset the failed login attempt counter to 0 and set last_login to None each time a user is re-activated.

While I was at it I also created and solve issue:

https://github.com/muccg/django-useraudit/issues/6

