### PR TITLE
muccg/rdrf#837 fix re-activate link

### DIFF
--- a/useraudit/admin.py
+++ b/useraudit/admin.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 from django.urls import reverse
+from django.utils.html import format_html
 
 from useraudit import models as m
 
@@ -27,7 +28,7 @@ class LoginAttemptAdmin(admin.ModelAdmin):
             if user.is_active:
                 return "Active"
             activation_url = reverse("useraudit:reactivate_user", args=[user.id])
-            return "<a href='%s'>Activate</a>" % activation_url
+            return format_html(u"<a href='%s'>Activate</a>" % activation_url)
         except UserModel.DoesNotExist:
             return "N/A"
 

--- a/useraudit/views.py
+++ b/useraudit/views.py
@@ -21,8 +21,6 @@ def test_request_available(request):
 
 
 def reactivate_user(request, user_id):
-    assert False, reverse("admin:useraudit_loginattempt_changelist")
-
     user = _get_user(user_id)
     user.is_active = True
     user.save()


### PR DESCRIPTION
* the re-activate link html was displayed in plain text in the admin login attempts table.

* the re-activate url went through an assert False line triggering
an exception.