### PR TITLE
Reactivation user cleans the reason of the last deactivation via comm…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,11 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development"
     ],
-    zip_safe=True,
+    zip_safe=False,
     packages=[
         'useraudit',
         'useraudit.migrations',
+        'useraudit.management.commands',
     ],
-    include_package_date=True,
+    include_package_data=True,
 )

--- a/useraudit/management/commands/activate_user.py
+++ b/useraudit/management/commands/activate_user.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth import get_user_model
 from django.db import transaction
-
+from useraudit.models import UserDeactivation
 
 class Command(BaseCommand):
     help = """

--- a/useraudit/management/commands/activate_user.py
+++ b/useraudit/management/commands/activate_user.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from useraudit.models import UserDeactivation
 
+
 class Command(BaseCommand):
     help = """
        Activates an inactive user.

--- a/useraudit/management/commands/activate_user.py
+++ b/useraudit/management/commands/activate_user.py
@@ -30,3 +30,4 @@ class Command(BaseCommand):
             return
         user.is_active = True
         user.save()
+        UserDeactivation.objects.filter(username=user.username).delete()

--- a/useraudit/views.py
+++ b/useraudit/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from .models import LoginAttemptLogger
+from .models import LoginAttemptLogger, UserDeactivation
 from . import middleware
 
 
@@ -24,6 +24,7 @@ def reactivate_user(request, user_id):
     user = _get_user(user_id)
     user.is_active = True
     user.save()
+    UserDeactivation.objects.filter(username=user.username).delete()
     login_attempt_logger.reset(user.username)
     return HttpResponseRedirect(reverse("admin:useraudit_loginattempt_changelist"))
 


### PR DESCRIPTION
if a user deactivated user have been locket, when you reactive the user via url /reactivate or command line, the deactivion log isn't cleaned.

1. Activate LOGIN_FAILURE_LIMIT = 3
2. try login 3 times with wrong password, user is deactivated with TOO_MANY_FAILED_LOGINS
3. Reactivate the user via backend or command line
4. try to log again with wrong password, still have 2 intents, but the model still have TOO_MANY_FAILED_LOGINS for him.


